### PR TITLE
Python 2.5 compatibility for graph_api.py

### DIFF
--- a/facepy/graph_api.py
+++ b/facepy/graph_api.py
@@ -194,7 +194,7 @@ class GraphAPI(object):
 
         try:
             data = json.loads(data)
-        except ValueError as e:
+        except ValueError:
             return data
 
         # Facebook's Graph API sometimes responds with 'true' or 'false'. Facebook offers no documentation


### PR DESCRIPTION
I've removed a python 2.6-ism from `graph_api.py` in the `try/except` block that seems to be the only blocker for python 2.5 compatibility.
