### PR TITLE
Remove data squash

### DIFF
--- a/facepy/graph_api.py
+++ b/facepy/graph_api.py
@@ -132,16 +132,11 @@ class GraphAPI(object):
         result = self._parse(response.content)
 
         try:
-            obj = result['data']
-        except (KeyError, TypeError):
-            obj = result
-
-        try:
             next_url = result['paging']['next']
         except (KeyError, TypeError):
             next_url = None
 
-        return obj, next_url
+        return result, next_url
 
     def _query(self, method, path, data={}, page=False):
         """

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -91,4 +91,4 @@ def test_search():
         type = 'post'
     )
 
-    assert isinstance(results, list)
+    assert isinstance(results['data'], list)


### PR DESCRIPTION
Removes the squashing of `data` key in the returned data.

Closes #14.
