### PR TITLE
Batch API response can be empty

### DIFF
--- a/facepy/graph_api.py
+++ b/facepy/graph_api.py
@@ -111,7 +111,7 @@ class GraphAPI(object):
         )
 
         for response, request in zip(responses, requests):
-            if 'body' in response:
+            if response:
                 data = json.loads(response['body'])
             else:
                 yield None


### PR DESCRIPTION
See https://developers.facebook.com/docs/reference/api/batch/, section **Specifying dependencies between operations in the request**. There is also example of such response:

```
[
    null,
    { "code": 200,
      "headers":[
          { "name":"Content-Type", 
            "value":"text/javascript; charset=UTF-8"}
      ],
      "body":"{\"data\": [{…}]}}
]
```

I tested my fix on real data.
