### PR TITLE
Moved the inner Exception classes of GraphAPI into exceptions.py

### DIFF
--- a/facepy/exceptions.py
+++ b/facepy/exceptions.py
@@ -1,2 +1,19 @@
 class FacepyError(Exception):
     """Base class for exceptions raised by Facepy."""
+
+
+class FacebookError(FacepyError):
+    """Exception for errors returned by the Graph API."""
+
+    def __init__(self, message, code):
+        super(FacebookError, self).__init__(message)
+
+        self.code = code
+
+
+class OAuthError(FacebookError):
+    """Exception for errors specifically related to OAuth."""
+
+
+class HTTPError(FacepyError):
+    """Exception for transport errors."""

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -5,6 +5,7 @@ import json
 from mock import patch, call, Mock as mock
 from nose.tools import *
 
+from facepy import exceptions
 from facepy import GraphAPI
 
 TEST_USER_ACCESS_TOKEN = '...'
@@ -91,7 +92,7 @@ def test_get():
 
     try:
         graph.get('me')
-    except GraphAPI.FacebookError as e:
+    except exceptions.FacebookError as e:
         assert e.code == 1
     else:
         assert False, "Error shoud have been raised."
@@ -110,7 +111,7 @@ def test_get():
 
     try:
         graph.get('me')
-    except GraphAPI.FacebookError as e:
+    except exceptions.FacebookError as e:
         assert e.message == 'The action you\'re trying to publish is invalid'
         assert e.code == None
     else:
@@ -136,7 +137,7 @@ def test_get_with_retries():
 
     try:
         graph.get('me', retry=3)
-    except GraphAPI.FacebookError:
+    except exceptions.FacebookError:
         pass
 
     assert mock_request.call_args_list == [


### PR DESCRIPTION
I was having trouble mocking out GraphAPI via the following code 

```
def test_my_view(self):
    with patch('facepy.graphy_api.GraphAPI) as ga:
          ....
```

I would get the following stack track trace

```
 ../lib/python2.6/site-packages/facepy/graph_api.py", line 275, in __init__
      super(GraphAPI.FacebookError, self).__init__(message)
 TypeError: super() argument 1 must be type, not MagicMock
```

This way I can mock out GraphAPI
