### PR TITLE
Chaging next_url default from None to an empty string

### DIFF
--- a/facepy/graph_api.py
+++ b/facepy/graph_api.py
@@ -198,7 +198,7 @@ class GraphAPI(object):
             try:
                 next_url = result['paging']['next']
             except (KeyError, TypeError):
-                next_url = None
+                next_url = ''
 
             return result, next_url
 

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -135,6 +135,28 @@ def test_paged_get():
     assert_equal(index, 1)
 
 @with_setup(mock, unmock)
+def test_pagination_without_paging_next():
+    graph = GraphAPI('<access token>')
+    limit = 2
+
+    mock_request.return_value.content = json.dumps({
+        'data': [
+            {
+                'message': 'He\'s a complicated man. And the only one that understands him is his woman',
+            },
+        ],
+        'paging': {
+        }
+    })
+
+    pages = graph.get('herc/posts', page=True, limit=limit)
+
+    for index, page in enumerate(pages):
+        pass
+
+    assert_equal(index, 0)
+
+@with_setup(mock, unmock)
 def test_get_with_errors():
     graph = GraphAPI('<access token>')
 


### PR DESCRIPTION
This way pagination won't break even if `paging` metadata is broken or not included.

I've added a test that was failing and a simple fix for it.

Thanks, cheers
Miguel
