### PR TITLE
Message is not displayed when exception is raised

### DIFF
--- a/facepy/exceptions.py
+++ b/facepy/exceptions.py
@@ -1,15 +1,17 @@
 class FacepyError(Exception):
     """Base class for exceptions raised by Facepy."""
 
-    def __init__(self, message):
-        self.message = message
-
 class FacebookError(FacepyError):
     """Exception for Facebook errors."""
 
     def __init__(self, message=None, code=None):
         self.message = message
         self.code = code
+
+        if self.code:
+            message = '[%s] %s' % (self.code, self.message)
+
+        super(FacebookError, self).__init__(message)
 
 class OAuthError(FacebookError):
     """Exception for Facebook errors specifically related to OAuth."""

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -4,6 +4,7 @@ from nose.tools import *
 
 from facepy import *
 from facepy.graph_api import GraphAPI
+from facepy.exceptions import FacebookError
 import cPickle
 
 def test_facepy_error():
@@ -11,6 +12,19 @@ def test_facepy_error():
         raise FacepyError('<message>')
     except FacepyError as exception:
         assert exception.message == '<message>'
+        assert exception.__str__() == '<message>'
+        assert exception.__repr__() == "FacepyError('<message>',)"
+        assert exception.__unicode__() == u'<message>'
+
+def test_facebook_error():
+    try:
+        raise FacebookError('<message>', 100)
+    except FacebookError as exception:
+        assert exception.message == '<message>'
+        assert exception.code == 100
+        assert exception.__str__() == '[100] <message>'
+        assert exception.__repr__() == "FacebookError('[100] <message>',)"
+        assert exception.__unicode__() == u'[100] <message>'
 
 def test_facebookerror_can_be_pickled():
     try:


### PR DESCRIPTION
Currently, the custom exceptions are not displayed correctly when raised
and hide the actual message.

Before:

``` python
>>> facepy.exceptions.FacepyError('doh')
FacepyError()
>>> facepy.exceptions.FacebookError('doh', 100)
FacebookError()
```

After:

``` python
>>> facepy.exceptions.FacepyError('doh')
FacepyError('doh',)
>>> facepy.exceptions.FacebookError('doh', 100)
FacebookError('[100] doh',)
```

This simple change should make them behave as expected.
