### PR TITLE
Prevents KeyErrors when Facebook provides signed requests with missing page data

### DIFF
--- a/facepy/signed_request.py
+++ b/facepy/signed_request.py
@@ -46,9 +46,9 @@ class SignedRequest(object):
         self.data = self.raw.get('app_data', None)
 
         self.page = self.Page(
-            id=self.raw['page']['id'],
-            is_liked=self.raw['page']['liked'],
-            is_admin=self.raw['page']['admin']
+            id=self.raw['page'].get('id'),
+            is_liked=self.raw['page'].get('liked'),
+            is_admin=self.raw['page'].get('admin')
         ) if 'page' in self.raw else None
 
         self.user = self.User(

--- a/tests/test_signed_request.py
+++ b/tests/test_signed_request.py
@@ -17,7 +17,7 @@ TEST_SIGNED_REQUEST = u'' \
     'c3FxayIsInVzZXIiOnsiY291bnRyeSI6Im5vIiwibG9jYWxlIjoiZW5fVVMiLC' \
     'JhZ2UiOnsibWluIjoyMX19LCJ1c2VyX2lkIjoiNDk5NzI5MTI5In0'
 
-TEST_SIGNED_REQUEST__UNKNOWN_ALGORITHM = u'' \
+TEST_SIGNED_REQUEST_UNKNOWN_ALGORITHM = u'' \
     'HjPZBDNttKrX_DBxH-fD78wmqP5O7eDcvjE9ToayKb0=.eyJ1c2VyX2lkIjoiN' \
     'Dk5NzI5MTI5IiwiYWxnb3JpdGhtIjoiVU5LTk9XTl9BTEdPUklUSE0iLCJleHB' \
     'pcmVzIjowLCJvYXV0aF90b2tlbiI6IjE4MTI1OTcxMTkyNTI3MHwxNTcwYTU1M' \
@@ -25,6 +25,15 @@ TEST_SIGNED_REQUEST__UNKNOWN_ALGORITHM = u'' \
     'Sa0hCRFNzcXFrIiwidXNlciI6eyJsb2NhbGUiOiJlbl9VUyIsImNvdW50cnkiO' \
     'iJubyIsImFnZSI6eyJtYXgiOjk5LCJtaW4iOjIxfX0sImlzc3VlZF9hdCI6MTM' \
     'wNjE3OTkwNH0='
+
+TEST_SIGNED_REQUEST_MISSING_PAGE_DATA = u'' \
+    '9B19RL7tj3nvf_SA8_PSFxTZxc7xA3LEjl2ww-OGRlk=.eyJ1c2VyX2lkIjoiN' \
+    'Dk5NzI5MTI5IiwiYWxnb3JpdGhtIjoiSE1BQy1TSEEyNTYiLCJleHBpcmVzIjo' \
+    'wLCJvYXV0aF90b2tlbiI6IjE4MTI1OTcxMTkyNTI3MHwxNTcwYTU1M2FkNjYwN' \
+    'TcwNWQxYjdhNWYuMS00OTk3MjkxMjl8OFhxTVJoQ1dES3RwRy1pX3pSa0hCRFN' \
+    'zcXFrIiwidXNlciI6eyJsb2NhbGUiOiJlbl9VUyIsImNvdW50cnkiOiJubyIsI' \
+    'mFnZSI6eyJtYXgiOjk5LCJtaW4iOjIxfX0sImlzc3VlZF9hdCI6MTMwNjE3OTk' \
+    'wNCwicGFnZSI6e319'
 
 TEST_FACEBOOK_APPLICATION_SECRET_KEY = '214e4cb484c28c35f18a70a3d735999b'
 
@@ -80,6 +89,13 @@ def test_initialize_signed_request():
         },
         'issued_at': 1306179904
     }
+
+
+def test_signed_request_missing_page_data():
+    try:
+        SignedRequest(TEST_SIGNED_REQUEST_MISSING_PAGE_DATA, TEST_FACEBOOK_APPLICATION_SECRET_KEY)
+    except KeyError:
+        raise AssertionError('Missing page data in signed request')
 
 
 def test_signed_request_page_url():
@@ -153,13 +169,13 @@ def test_parse_signed_request_unknown_algorithm():
     assert_raises(
         SignedRequest.Error,
         SignedRequest.parse,
-        signed_request=TEST_SIGNED_REQUEST__UNKNOWN_ALGORITHM,
+        signed_request=TEST_SIGNED_REQUEST_UNKNOWN_ALGORITHM,
         application_secret_key=TEST_FACEBOOK_APPLICATION_SECRET_KEY
     )
 
 
 def test_parse_signed_request_incorrect_signature():
-    encoded_signature, _ = (str(string) for string in TEST_SIGNED_REQUEST__UNKNOWN_ALGORITHM.split('.', 2))
+    encoded_signature, _ = (str(string) for string in TEST_SIGNED_REQUEST_UNKNOWN_ALGORITHM.split('.', 2))
     _, encoded_payload = (str(string) for string in TEST_SIGNED_REQUEST.split('.', 2))
 
     assert_raises(


### PR DESCRIPTION
Fixes #72
