### PR TITLE
Parse floating-point numbers as decimal.Decimal (#86)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,6 +18,7 @@ Patches and suggestions
 * Jan Javorek
 * Tomasz Wysocki
 * J. Javier Maestro
+* Éric Araujo
 * Miguel Araujo
 * Marc Abramowitz
 * ZacS803

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,14 @@
 History
 -------
 
+Unreleased
+++++++++++
+
+* Changed ``GraphAPI`` methods to return ``decimal.Decimal`` instances for
+  floating-point numbers instead of ``float``, which can cause precision
+  losses not acceptable for financial operations.
+
+
 0.8.4
 +++++
 

--- a/facepy/graph_api.py
+++ b/facepy/graph_api.py
@@ -5,6 +5,7 @@ except ImportError:
 import requests
 
 from urllib import urlencode
+from decimal import Decimal
 
 from facepy.exceptions import *
 
@@ -30,6 +31,9 @@ class GraphAPI(object):
                      iterates over each page of results.
         :param retry: An integer describing how many times the request may be retried.
         :param options: Graph API parameters such as 'limit', 'offset' or 'since'.
+
+        Floating-point numbers will be returned as :class:`decimal.Decimal`
+        instances.
 
         See `Facebook's Graph API documentation <http://developers.facebook.com/docs/reference/api/>`_
         for an exhaustive list of parameters.
@@ -259,7 +263,7 @@ class GraphAPI(object):
         :param data: A string describing the Graph API's response.
         """
         try:
-            data = json.loads(data)
+            data = json.loads(data, parse_float=Decimal)
         except ValueError:
             return data
 

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -1,6 +1,7 @@
 """Tests for the ``graph_api`` module."""
 
 import json
+import decimal
 
 from nose.tools import *
 from mock import patch, MagicMock
@@ -110,6 +111,16 @@ def test_get_with_fields():
             'fields': 'id,first_name,last_name'
         }
     )
+
+
+@with_setup(mock, unmock)
+def test_get_with_fpnum():
+    graph = GraphAPI('<access token>')
+    mock_request.return_value.content = '{"payout": 0.94}'
+
+    resp = graph.get('<paymend_id>')
+
+    assert_equal(resp, {'payout': decimal.Decimal('0.94')})
 
 
 @with_setup(mock, unmock)


### PR DESCRIPTION
I added a changelog entry but did not change the version number: you may judge this is a big enough change to be 0.9.0 to warn users of possible breakage, given that for example the default Python JSON encoder does not handle Decimals, so if people take values returned by GraphAPI.get and send them to another API with JSON, they may need to handle Decimals.
