### PR TITLE
Had an error with unicode URLs failing, so included a decode, reencode

### DIFF
--- a/facepy/graph_api.py
+++ b/facepy/graph_api.py
@@ -252,12 +252,12 @@ class GraphAPI(object):
 
         # Convert option lists to comma-separated values.
         for key in data:
-            if isinstance(data[key], (list, set, tuple)) and all([isinstance(item, str) for item in data[key]]):
+            if isinstance(data[key], (list, set, tuple)) and all([isinstance(item, basestring) for item in data[key]]):
                 data[key] = ','.join(data[key])
 
         # Support absolute paths too
         if not path.startswith('/'):
-            path = '/' + str(path)
+            path = '/' + unicode(path.decode('utf-8'))
 
         url = '%s%s' % (self.url, path)
 


### PR DESCRIPTION
statement in the path call in line 260.

Here's a sample URL that was failing without this:

success = graph.get('https://www.facebook.com/universityofmichigan')
fail = graph.get('https://www.facebook.com/christophernewportuniversity‎')
