### PR TITLE
Raise specialized exception for facebook internal server errors.

### DIFF
--- a/facepy/exceptions.py
+++ b/facepy/exceptions.py
@@ -24,3 +24,6 @@ class HTTPError(FacepyError):
 
 class SignedRequestError(FacepyError):
     """Exception for invalid signed requests."""
+
+class InternalFacebookError(FacebookError):
+    """Exception for Facebook internal server error."""

--- a/facepy/graph_api.py
+++ b/facepy/graph_api.py
@@ -256,7 +256,7 @@ class GraphAPI(object):
                     response = self.session.request(method, url, data=data, files=files,
                         verify=self.verify_ssl_certificate, timeout=self.timeout)
                 if response.status_code == 500:
-                    raise FacebookError("Internal Facebook error ocurred.")
+                    raise InternalFacebookError("Internal Facebook error ocurred.")
             except requests.RequestException as exception:
                 raise HTTPError(exception)
 


### PR DESCRIPTION
This Exception should be special, because you would want to retry your request if it happens. This is not the case for just any FacebookException.
