### PR TITLE
Handle unknown statuses.

### DIFF
--- a/facepy/graph_api.py
+++ b/facepy/graph_api.py
@@ -257,6 +257,8 @@ class GraphAPI(object):
                         verify=self.verify_ssl_certificate, timeout=self.timeout)
                 if response.status_code == 500:
                     raise FacebookError("Internal Facebook error ocurred.")
+                if response.status_code != 200:
+                    raise HTTPError('Got invalid status_code %s.' % response.status_code)
             except requests.RequestException as exception:
                 raise HTTPError(exception)
 

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -11,6 +11,7 @@ from mock import patch, MagicMock
 from requests.exceptions import ConnectionError
 
 from facepy import GraphAPI
+from facepy import exceptions
 
 
 patch = patch('requests.session')
@@ -38,6 +39,7 @@ def test_get():
         'link': 'http://facebook.com/herc',
         'username': 'herc',
     })
+    mock_request.return_value.status_code = 200
 
     graph.get('me')
 
@@ -65,6 +67,7 @@ def test_get_with_nested_parameters():
         'link': 'http://facebook.com/herc',
         'username': 'herc',
     })
+    mock_request.return_value.status_code = 200
 
     graph.get('me', foo={'bar': 'baz'})
 
@@ -93,6 +96,7 @@ def test_get_with_appsecret():
         'link': 'http://facebook.com/herc',
         'username': 'herc',
     })
+    mock_request.return_value.status_code = 200
 
     graph.get('me')
 
@@ -118,6 +122,7 @@ def test_get_with_fields():
         'first_name': 'Thomas',
         'last_name': 'Hauk'
     })
+    mock_request.return_value.status_code = 200
 
     graph.get('me', fields=['id', 'first_name', 'last_name'])
 
@@ -152,6 +157,7 @@ def test_get_with_fields():
 def test_get_with_fpnum():
     graph = GraphAPI('<access token>')
     mock_request.return_value.content = '{"payout": 0.94}'
+    mock_request.return_value.status_code = 200
 
     resp = graph.get('<paymend_id>')
 
@@ -163,6 +169,7 @@ def test_forbidden_get():
     graph = GraphAPI('<access token>')
 
     mock_request.return_value.content = 'false'
+    mock_request.return_value.status_code = 200
 
     assert_raises(GraphAPI.FacebookError, graph.get, 'me')
 
@@ -210,9 +217,10 @@ def test_paged_get():
     def side_effect(*args, **kwargs):
         response = responses.pop(0)
 
-        return MagicMock(content=json.dumps(response))
+        return MagicMock(content=json.dumps(response), status_code=200)
 
     mock_request.side_effect = side_effect
+    mock_request.status_code=200
 
     pages = graph.get('herc/posts', page=True)
 
@@ -236,6 +244,7 @@ def test_pagination_without_paging_next():
         'paging': {
         }
     })
+    mock_request.return_value.status_code = 200
 
     pages = graph.get('herc/posts', page=True, limit=limit)
 
@@ -256,6 +265,7 @@ def test_get_with_errors():
             'message': 'An unknown error occurred'
         }
     })
+    mock_request.return_value.status_code = 200
 
     assert_raises(GraphAPI.FacebookError, graph.get, 'me')
 
@@ -264,6 +274,7 @@ def test_get_with_errors():
         'error_code': 1,
         'error_msg': 'An unknown error occurred',
     })
+    mock_request.return_value.status_code = 200
 
     assert_raises(GraphAPI.FacebookError, graph.get, 'me')
 
@@ -271,6 +282,7 @@ def test_get_with_errors():
     mock_request.return_value.content = json.dumps({
         'error_msg': 'The action you\'re trying to publish is invalid'
     })
+    mock_request.return_value.status_code = 200
 
     assert_raises(GraphAPI.FacebookError, graph.get, 'me')
 
@@ -287,6 +299,7 @@ def test_fql():
         'link': 'http://facebook.com/herc',
         'username': 'herc',
     })
+    mock_request.return_value.status_code = 200
 
     try:
         graph.fql('SELECT id,name,first_name,last_name,username FROM user WHERE uid=me()')
@@ -312,6 +325,7 @@ def test_post():
     mock_request.return_value.content = json.dumps({
         'id': 1
     })
+    mock_request.return_value.status_code = 200
 
     graph.post(
         path='me/feed',
@@ -336,6 +350,7 @@ def test_post_with_files():
     graph = GraphAPI('<access token>')
 
     mock_request.return_value.content = 'true'
+    mock_request.return_value.status_code = 200
 
     graph.post(
         path='me/photos',
@@ -348,6 +363,7 @@ def test_forbidden_post():
     graph = GraphAPI('<access token>')
 
     mock_request.return_value.content = 'false'
+    mock_request.return_value.status_code = 200
 
     assert_raises(GraphAPI.FacebookError, graph.post, 'me')
 
@@ -357,6 +373,7 @@ def test_delete():
     graph = GraphAPI('<access token>')
 
     mock_request.return_value.content = 'true'
+    mock_request.return_value.status_code = 200
 
     graph.delete('1')
 
@@ -377,6 +394,7 @@ def test_forbidden_delete():
     graph = GraphAPI('<access token>')
 
     mock_request.return_value.content = 'false'
+    mock_request.return_value.status_code = 200
 
     assert_raises(GraphAPI.FacebookError, graph.delete, 'me')
 
@@ -395,6 +413,7 @@ def test_search():
             }
         ]
     })
+    mock_request.return_value.status_code = 200
 
     graph.search(
         term='shaft quotes',
@@ -435,6 +454,7 @@ def test_batch():
             'body': '{"foo": "bar"}'
         }
     ])
+    mock_request.return_value.status_code = 200
 
     requests = [
         {'method': 'GET', 'relative_url': 'me/friends'},
@@ -480,6 +500,7 @@ def test_batch_with_empty_responses():
             'body': '{"foo": "bar"}'
         }
     ])
+    mock_request.return_value.status_code = 200
 
     requests = [
         {'method': 'GET', 'relative_url': 'me/friends'},
@@ -513,6 +534,7 @@ def test_batch_with_errors():
             'body': '{"error_code": 1, "error_msg": "An unknown error occurred"}'
         }
     ])
+    mock_request.return_value.status_code = 200
 
     requests = [
         {'method': 'GET', 'relative_url': 'me/friends'},
@@ -540,6 +562,7 @@ def test_batch_error_references_request():
             'body': '{"error_code": 1, "error_msg": "An unknown error occurred"}'
         }
     ])
+    mock_request.return_value.status_code = 200
 
     requests = [
         {'method': 'GET', 'relative_url': 'me'}
@@ -559,7 +582,7 @@ def test_batch_over_50_requests():
     def side_effect_batch_size(*args, **kwargs):
         batch_size = len(json.loads(kwargs['data']['batch']))
         if batch_size > 50:
-            return MagicMock(content='{"error":{"message":"Too many requests in batch message. Maximum batch size is 50","type":"GraphBatchException"}}')
+            return MagicMock(content='{"error":{"message":"Too many requests in batch message. Maximum batch size is 50","type":"GraphBatchException"}}', status_code=200)
         else:
             return MagicMock(content=json.dumps([
                 {
@@ -569,9 +592,10 @@ def test_batch_over_50_requests():
                     ],
                     'body': '{"foo": "bar"}'
                 } for i in range(batch_size)
-            ]))
+            ]), status_code=200)
 
     mock_request.side_effect = side_effect_batch_size
+    mock_request.return_value.status_code = 200
 
     requests = [dict(method="GET", relative_url="me?fields=username") for i in range(60)]
 
@@ -595,6 +619,7 @@ def test_oauth_error():
             'code': 2500
         }
     })
+    mock_request.return_value.status_code = 200
 
     assert_raises(GraphAPI.OAuthError, graph.get, 'me')
 
@@ -617,6 +642,15 @@ def test_if_raises_error_on_facebook_500():
     assert_raises(GraphAPI.FacebookError, graph.get, 'me')
 
 @with_setup(mock, unmock)
+def test_if_raises_error_on_unknow_status():
+    graph = GraphAPI('<access token>')
+
+    mock_request.return_value.status_code = 123
+    mock_request.return_value.content = ''
+
+    assert_raises(exceptions.FacepyError, graph.get, 'me')
+
+@with_setup(mock, unmock)
 def test_retry():
     graph = GraphAPI('<access token>')
 
@@ -626,6 +660,7 @@ def test_retry():
             'message': 'An unknown error occurred'
         }
     })
+    mock_request.return_value.status_code = 500
 
     assert_raises(GraphAPI.FacebookError, graph.get, 'me', retry=3)
     assert_equal(len(mock_request.call_args_list), 4)
@@ -636,6 +671,7 @@ def test_get_unicode_url():
     graph = GraphAPI('<access token>')
 
     mock_request.return_value.content = json.dumps({})
+    mock_request.return_value.status_code = 200
 
     response = graph.get('https://www.facebook.com/christophernewportuniversity‎')
 
@@ -648,6 +684,7 @@ def test_timeouts():
     graph = GraphAPI('<access token>', timeout=1)
 
     mock_request.return_value.content = json.dumps({})
+    mock_request.return_value.status_code = 200
 
     graph.get('me')
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -23,6 +23,7 @@ def unmock():
 @with_setup(mock, unmock)
 def test_get_extended_access_token():
     mock_request.return_value.content = 'access_token=<extended access token>&expires=5183994'
+    mock_request.return_value.status_code = 200
 
     access_token, expires_at = get_extended_access_token(
         '<access token>',
@@ -51,6 +52,7 @@ def test_get_extended_access_token():
 @with_setup(mock, unmock)
 def test_get_extended_access_token_no_expiry():
     mock_request.return_value.content = 'access_token=<extended access token>'
+    mock_request.return_value.status_code = 200
 
     access_token, expires_at = get_extended_access_token(
         '<access token>',
@@ -78,6 +80,7 @@ def test_get_extended_access_token_no_expiry():
 @with_setup(mock, unmock)
 def test_get_application_access_token():
     mock_request.return_value.content = 'access_token=...'
+    mock_request.return_value.status_code = 200
 
     access_token = get_application_access_token('<application id>', '<application secret key>')
 
@@ -100,6 +103,7 @@ def test_get_application_access_token():
 @with_setup(mock, unmock)
 def test_get_application_access_token_raises_error():
     mock_request.return_value.content = 'An unknown error occurred'
+    mock_request.return_value.status_code = 200
 
     assert_raises(
         GraphAPI.FacebookError,


### PR DESCRIPTION
This is draft. I'm not sure about it's correctness.

Facepy have problems with handling unsuspected Facebook responses. It is showed in following code:
* https://github.com/jgorset/facepy/pull/115
* https://github.com/jgorset/facepy/pull/116
* https://github.com/jgorset/facepy/commit/39426bb1cb0efb1b2b254567f91e9ff12049c192

To handle this problem correctly status_code should be always checked and exception raised if we can't recognize returned status code.

In this way we will have elegant exception for new status codes, rather than random problems.

Exception class choice.
FacebookError is not good, because we don't now if it was error. HttpError is also not good, because Http did fine. I propose to use FacepyError, because problem lies in Facepy (we don't recognize, probably valid Facebook response).

Problem with this commit.
This commit is a draft. In fact I don't know if statuses added to tests (mostly 200) are in fact statuses returned by Facebook in real usege. For examples like "Too many requests in batch message. Maximum batch size is" i would expect different status from Facebook than 200.