### PR TITLE
Support Facebook error messages on HTTP 5XX

### DIFF
--- a/facepy/exceptions.py
+++ b/facepy/exceptions.py
@@ -25,5 +25,6 @@ class HTTPError(FacepyError):
 class SignedRequestError(FacepyError):
     """Exception for invalid signed requests."""
 
+
 class InternalFacebookError(FacebookError):
     """Exception for Facebook internal server error."""

--- a/facepy/graph_api.py
+++ b/facepy/graph_api.py
@@ -224,11 +224,11 @@ class GraphAPI(object):
 
         if(data):
             data = dict(
-                 (k.replace('_sqbro_', '['), v) for k, v in data.items())
+                (k.replace('_sqbro_', '['), v) for k, v in data.items())
             data = dict(
-                 (k.replace('_sqbrc_', ']'), v) for k, v in data.items())
+                (k.replace('_sqbrc_', ']'), v) for k, v in data.items())
             data = dict(
-                 (k.replace('__', ':'), v) for k, v in data.items())
+                (k.replace('__', ':'), v) for k, v in data.items())
         data = data or {}
 
         def load(method, url, data):
@@ -240,8 +240,10 @@ class GraphAPI(object):
 
             try:
                 if method in ['GET', 'DELETE']:
-                    response = self.session.request(method, url, params=data, allow_redirects=True,
-                     verify=self.verify_ssl_certificate, timeout=self.timeout)
+                    response = self.session.request(
+                        method, url, params=data, allow_redirects=True,
+                        verify=self.verify_ssl_certificate, timeout=self.timeout
+                    )
 
                 if method in ['POST', 'PUT']:
                     files = {}
@@ -253,8 +255,10 @@ class GraphAPI(object):
                     for key in files:
                         data.pop(key)
 
-                    response = self.session.request(method, url, data=data, files=files,
-                        verify=self.verify_ssl_certificate, timeout=self.timeout)
+                    response = self.session.request(
+                        method, url, data=data, files=files,
+                        verify=self.verify_ssl_certificate, timeout=self.timeout
+                    )
 
                 if 500 <= response.status_code < 600:
                     # Facebook 5XX errors usually come with helpful messages

--- a/facepy/signed_request.py
+++ b/facepy/signed_request.py
@@ -52,7 +52,7 @@ class SignedRequest(object):
             is_admin=self.raw['page'].get('admin')
         ) if 'page' in self.raw else None
 
-        if not 'user' in self.raw:
+        if 'user' not in self.raw:
             self.fetch_user_data_and_token()
 
         self.user = self.User(
@@ -76,10 +76,9 @@ class SignedRequest(object):
 
         app_token = get_application_access_token(self.application_id, self.application_secret_key)
         graph = GraphAPI(app_token)
-        
+
         qs = graph.get('oauth/access_token', code=self.raw['code'], redirect_uri='', client_id=self.application_id, client_secret=self.application_secret_key)
         self.raw['oauth_token'] = parse_qs(qs)['access_token'][0]
-        #import ipdb; ipdb.set_trace()
         self.raw['expires'] = time.time() + int(parse_qs(qs)['expires'][0])
         self.raw['user'] = graph.get(self.raw['user_id'])
 

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -3,8 +3,6 @@
 """Tests for the ``graph_api`` module."""
 import json
 import decimal
-import hashlib
-import hmac
 
 from nose.tools import *
 from mock import patch, MagicMock
@@ -654,6 +652,7 @@ def test_query_transport_error():
 
     assert_raises(GraphAPI.HTTPError, graph.get, 'me')
 
+
 @with_setup(mock, unmock)
 def test_if_raises_error_on_facebook_500():
     graph = GraphAPI('<access token>')
@@ -662,6 +661,7 @@ def test_if_raises_error_on_facebook_500():
     mock_request.return_value.content = ''
 
     assert_raises(GraphAPI.FacebookError, graph.get, 'me')
+
 
 @with_setup(mock, unmock)
 def test_retry():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -77,6 +77,7 @@ def test_get_extended_access_token_no_expiry():
     assert_equal(access_token, '<extended access token>')
     assert expires_at is None
 
+
 @with_setup(mock, unmock)
 def test_get_application_access_token():
     mock_request.return_value.status_code = 200


### PR DESCRIPTION
While working with the Ads API, I noticed that if Facebook responds with an `HTTP 5XX` status code due to things such as validation errors, invalid actions, etc., the error response most of the times, if not always, contains a JSON object including a description of what is wrong with the request, which is being ignored when a response has a status code of 5XX.

I consider this message is useful to have in the exception being raised for debugging purposes or to communicate the end user why Facebook didn't process a request, assuming the user's input data is invalid.
