### PR TITLE
Exposing additional information from an error response

### DIFF
--- a/facepy/exceptions.py
+++ b/facepy/exceptions.py
@@ -4,9 +4,15 @@ class FacepyError(Exception):
 
 class FacebookError(FacepyError):
     """Exception for Facebook errors."""
-    def __init__(self, message=None, code=None):
+    def __init__(self, message=None, code=None, error_data=None, error_subcode=None,
+                 is_transient=None, error_user_title=None, error_user_msg=None):
         self.message = message
         self.code = code
+        self.error_data = error_data
+        self.error_subcode = error_subcode
+        self.is_transient = is_transient
+        self.error_user_title = error_user_title
+        self.error_user_msg = error_user_msg
 
         if self.code:
             message = '[%s] %s' % (self.code, self.message)

--- a/facepy/graph_api.py
+++ b/facepy/graph_api.py
@@ -352,6 +352,18 @@ class GraphAPI(object):
 
         return url
 
+    def _get_error_params(self, error_obj):
+        error_params = {}
+        error_fields = ['message', 'code', 'error_subcode', 'error_user_msg',
+                        'is_transient', 'error_data', 'error_user_title']
+
+        if 'error' in error_obj:
+            error_obj = error_obj['error']
+
+        for field in error_fields:
+            error_params[field] = error_obj.get(field)
+        return error_params
+
     def _parse(self, data):
         """
         Parse the response from Facebook's Graph API.
@@ -388,17 +400,11 @@ class GraphAPI(object):
                 else:
                     exception = FacebookError
 
-                raise exception(
-                    error.get('message'),
-                    error.get('code', None)
-                )
+                raise exception(**self._get_error_params(data))
 
             # Facebook occasionally reports errors in its legacy error format.
             if 'error_msg' in data:
-                raise FacebookError(
-                    data.get('error_msg'),
-                    data.get('error_code', None)
-                )
+                raise FacebookError(**self._get_error_params(data))
 
         return data
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -4,17 +4,33 @@ try:
 except ImportError:
     import pickle
 
-
 from nose.tools import *
-
 from facepy import *
+
+TEST_ERROR_OBJ = {
+  'error': {
+    'message': '<message>',
+    'code': 100,
+    'error_data': {
+      'blame_field_specs': [
+        [
+          'account_id'
+        ]
+      ]
+    },
+    'error_subcode': 1234567,
+    'is_transient': False,
+    'error_user_title': '<error_user_title>',
+    'error_user_msg': '<error_user_msg>'
+  }
+}
 
 
 def test_facepy_error():
     try:
-        raise FacepyError('<message>')
+        raise FacepyError(TEST_ERROR_OBJ['error']['message'])
     except FacepyError as exception:
-        if hasattr(exception, "message"):
+        if hasattr(exception, 'message'):
             assert_equal(exception.message, '<message>')
         assert_equal(exception.__str__(), '<message>')
         assert_equal(exception.__repr__(), 'FacepyError(\'<message>\',)')
@@ -22,30 +38,30 @@ def test_facepy_error():
 
 def test_facebook_error():
     try:
-        raise FacebookError('<message>', 100)
+        raise FacebookError(**TEST_ERROR_OBJ['error'])
     except FacebookError as exception:
-        assert_equal(exception.message, '<message>')
-        assert_equal(exception.code, 100)
+        for name, value in TEST_ERROR_OBJ['error'].items():
+            assert_equal(getattr(exception, name, None), value)
         assert_equal(exception.__str__(), '[100] <message>')
         assert_equal(exception.__repr__(), 'FacebookError(\'[100] <message>\',)')
 
 
 def test_facebookerror_can_be_pickled():
     try:
-        raise GraphAPI.FacebookError('<message>', '<code>')
+        raise GraphAPI.FacebookError(**TEST_ERROR_OBJ['error'])
     except FacepyError as exception:
         pickle.dumps(exception)
 
 
 def test_oautherror_can_be_pickled():
     try:
-        raise GraphAPI.OAuthError('<message>', '<code>')
+        raise GraphAPI.OAuthError(**TEST_ERROR_OBJ['error'])
     except FacepyError as exception:
         pickle.dumps(exception)
 
 
 def test_httperror_can_be_pickled():
     try:
-        raise GraphAPI.HTTPError('<message>')
+        raise GraphAPI.HTTPError(TEST_ERROR_OBJ['error']['message'])
     except FacepyError as exception:
         pickle.dumps(exception)


### PR DESCRIPTION
I've experienced that in some edge cases, facebook simply says `Invalid parameter` in the error `message` property. This is not useful at all in `facepy`'s exceptions as it doesn't really say anything and the real/useful error information is in other properties.

This pull request simply exposes such error information as exception attributes so that anyone who needs them have them handy and leaves the current representation untouched.