### PR TITLE
get_extended_access_token using api_version=2.3+ returns json instead…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ build
 *.egg-info
 .coverage
 .tox
+.python-version
+*.sublime-project

--- a/facepy/utils.py
+++ b/facepy/utils.py
@@ -29,7 +29,10 @@ def get_extended_access_token(access_token, application_id, application_secret_k
         fb_exchange_token=access_token
     )
 
-    components = parse_qs(response)
+    try:
+        components = parse_qs(response)
+    except AttributeError:  # api_version >= 2.3 returns a dict
+        return response['access_token'], None
 
     token = components['access_token'][0]
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,5 +7,7 @@
 envlist = py27, py33
 
 [testenv]
+setenv:
+  PYTHONWARNINGS=default
 commands = {envpython} setup.py nosetests
 deps = -rrequirements.txt


### PR DESCRIPTION
calling `utils.get_extended_access_token` with `api_version=2.3` returns json instead of querystring