### PR TITLE
Return HTTP headers in result

### DIFF
--- a/facepy/graph_api.py
+++ b/facepy/graph_api.py
@@ -271,6 +271,8 @@ class GraphAPI(object):
                 raise HTTPError(exception)
 
             result = self._parse(response.content)
+            if isinstance(result, dict):
+                result['headers'] = response.headers
 
             try:
                 next_url = result['paging']['next']

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -183,10 +183,11 @@ def test_get_with_fpnum():
     graph = GraphAPI('<access token>')
     mock_request.return_value.content = '{"payout": 0.94}'
     mock_request.return_value.status_code = 200
+    mock_request.return_value.headers = {}
 
     resp = graph.get('<paymend_id>')
 
-    assert_equal(resp, {'payout': decimal.Decimal('0.94')})
+    assert_equal(resp, {'payout': decimal.Decimal('0.94'), 'headers': {}})
 
 
 @with_setup(mock, unmock)
@@ -682,11 +683,12 @@ def test_get_unicode_url():
 
     mock_request.return_value.content = json.dumps({})
     mock_request.return_value.status_code = 200
+    mock_request.return_value.headers = {}
 
     response = graph.get('https://www.facebook.com/christophernewportuniversity‎')
 
     assert_true(mock_request.called)
-    assert_equal({}, response)
+    assert_equal({'headers': {}}, response)
 
 
 @with_setup(mock, unmock)


### PR DESCRIPTION
There is some useful information contained within the HTTP headers
received back from a graph API request.  Stash them away in
response['headers'] so that users can pull them out if they'd like.

One example of how they might be used is dynamic throttling based on the
Rate limiting header (X-App-Usage) described in [1].  For example:

    >>> response = graph.get(...)
    >>> usage = response['headers'].get('x-app-usage')
    >>> if usage is not None:
    ...    usage = loads(usage)
    ...    if max(usage.itervalues()) > 80:
    ...        # we're at 80% quota usage. Calm things down
    ...        throttle_down()

[1] https://developers.facebook.com/docs/graph-api/advanced/rate-limiting