### PR TITLE
Add fbtrace_id to FacebookError exception info

### DIFF
--- a/facepy/exceptions.py
+++ b/facepy/exceptions.py
@@ -5,7 +5,8 @@ class FacepyError(Exception):
 class FacebookError(FacepyError):
     """Exception for Facebook errors."""
     def __init__(self, message=None, code=None, error_data=None, error_subcode=None,
-                 is_transient=None, error_user_title=None, error_user_msg=None):
+                 is_transient=None, error_user_title=None, error_user_msg=None,
+                 fbtrace_id=None):
         self.message = message
         self.code = code
         self.error_data = error_data
@@ -13,6 +14,7 @@ class FacebookError(FacepyError):
         self.is_transient = is_transient
         self.error_user_title = error_user_title
         self.error_user_msg = error_user_msg
+        self.fbtrace_id = fbtrace_id
 
         if self.code:
             message = '[%s] %s' % (self.code, self.message)

--- a/facepy/graph_api.py
+++ b/facepy/graph_api.py
@@ -352,7 +352,8 @@ class GraphAPI(object):
     def _get_error_params(self, error_obj):
         error_params = {}
         error_fields = ['message', 'code', 'error_subcode', 'error_user_msg',
-                        'is_transient', 'error_data', 'error_user_title']
+                        'is_transient', 'error_data', 'error_user_title',
+                        'fbtrace_id']
 
         if 'error' in error_obj:
             error_obj = error_obj['error']

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -21,7 +21,8 @@ TEST_ERROR_OBJ = {
     'error_subcode': 1234567,
     'is_transient': False,
     'error_user_title': '<error_user_title>',
-    'error_user_msg': '<error_user_msg>'
+    'error_user_msg': '<error_user_msg>',
+    'fbtrace_id': '<fbtrace_id>',
   }
 }
 


### PR DESCRIPTION
Facebook needs the `fbtrace_id` to look into bugs.  Add it to the
`FacebookError` exception object so that it can be submitted with bug reports
to Facebook.