### PR TITLE
Remove the section of the documentation that covered the usage of FQL

### DIFF
--- a/docs/source/usage/graph-api.rst
+++ b/docs/source/usage/graph-api.rst
@@ -18,17 +18,10 @@ You may interact with Facebook's Graph API using the ``GraphAPI`` class::
         source = open('parrot.jpg')
     )
 
-    # Make a FQL query
-    graph.fql('SELECT name FROM user WHERE uid = me()')
 
-    # Make a FQL multiquery
-    graph.fql({
-        'rsvp_status': 'SELECT uid, rsvp_status FROM event_member WHERE eid=12345678',
-        'details': 'SELECT name, url, pic FROM profile WHERE id IN (SELECT uid FROM #rsvp_status)'
-    }
 
 .. autoclass:: facepy.GraphAPI
-    :members: get, post, delete, search, batch, fql
+    :members: get, post, delete, search, batch
 
 .. admonition:: See also
 


### PR DESCRIPTION
FQL is no longer supported from facebook or facepy so I removed the instructions for it in the documentation. It is a rather small change but people might get confused if that section remains