### PR TITLE
utils: Add default expiry for extended access tokens

### DIFF
--- a/facepy/utils.py
+++ b/facepy/utils.py
@@ -36,7 +36,7 @@ def get_extended_access_token(access_token, application_id, application_secret_k
         # api_version >= 2.3 returns a dict
         # Make tidier exception structure to handle expiry time on api_version >=2.3
         token = response['access_token']
-        expiry_countdown = response['expires_in'] # already integer from json 
+        expiry_countdown = response.get('expires_in', 3600) # already integer from json
     else:
         token = components['access_token'][0]
         try:


### PR DESCRIPTION
Sometimes Facebook breaks stuff [1-4] and doesn't include the `expires_in'
key in their response for getting extended access tokens.  Handle these
more gracefully by using a default expire time of 1 hour in the future.

Cc: @sponrad

[1] https://developers.facebook.com/bugs/1295065507275932/
[2] https://developers.facebook.com/bugs/857609027732074/
[3] https://developers.facebook.com/bugs/313603145778830/
[4] https://developers.facebook.com/bugs/1829057490667058/